### PR TITLE
Add content versioning to editor + event listener support for EditorSupport

### DIFF
--- a/cypher-codemirror/src/codemirror-cypher.js
+++ b/cypher-codemirror/src/codemirror-cypher.js
@@ -55,7 +55,8 @@ function fixColors(editor, editorSupport) {
 codemirror.registerHelper('lint', 'cypher', (text, options, editor) => {
   const editorSupport = editor.editorSupport;
   if (!editorSupport) return [];
-  editorSupport.update(text);
+  const version = editor.newContentVersion();
+  editorSupport.update(text, version);
 
   fixColors(editor, editorSupport);
 
@@ -102,6 +103,12 @@ export function createCypherEditor(input, settings) {
   const editor = codemirror(input, { ...settings, value: '' });
   editor.cypherMarkers = [];
   editor.editorSupport = editorSupport;
+  editor.version = 1;
+  editor.newContentVersion = function newContentVersion() {
+    this.version += 1;
+    return this.version;
+  };
+  editor.newContentVersion.bind(editor);
   editor.setValue(settings.value || '');
 
   return { editor, editorSupport };

--- a/cypher-codemirror/src/react/CypherCodeMirror.js
+++ b/cypher-codemirror/src/react/CypherCodeMirror.js
@@ -61,8 +61,27 @@ export default class CypherCodeMirror extends React.Component {
   componentDidMount() {
     const { editor, editorSupport } = createCypherEditor(this.input, this.settings);
     this.editor = editor;
-    this.editorSupport = editorSupport;
     this.editor.on('change', triggerAutocompletion);
+    this.editorSupport = editorSupport;
+    this.editorSupport.on('updated', () => {
+      console.log('UPDATED - this.editorSupport.version: ', this.editorSupport.version);
+      console.table(this.editorSupport.queriesAndCommands.map(stmt => stmt.getText()));
+    });
+    this.editorSupport.on('update', () => {
+      console.log('UPDATE - this.editor.version: ', this.editor.version);
+      console.log('UPDATE - this.editorSupport.version: ', this.editorSupport.version);
+      this.editorSupport
+        .ensureVersion(this.editor.version)
+        .then(() => {
+          console.log('ENSURE OK - this.editor.version: ', this.editor.version);
+          console.log('ENSURE OK - this.editorSupport.version: ', this.editorSupport.version);
+        })
+        .catch(() => {
+          console.error('Version not found');
+          console.log('ENSURE ERROR - this.editor.version: ', this.editor.version);
+          console.log('ENSURE ERROR - this.editorSupport.version: ', this.editorSupport.version);
+        });
+    });
     this.editorSupport.setSchema(this.schema);
   }
 

--- a/cypher-editor-support/src/util/retryOperation.js
+++ b/cypher-editor-support/src/util/retryOperation.js
@@ -1,0 +1,14 @@
+const wait = ms => new Promise(r => setTimeout(r, ms));
+
+export const retryOperation = (operation, delay, times) =>
+  new Promise((resolve, reject) => operation()
+      .then(resolve)
+      .catch((reason) => {
+        if (times - 1 > 0) {
+          return wait(delay)
+            .then(retryOperation.bind(null, operation, delay, times - 1))
+            .then(resolve)
+            .catch(reject);
+        }
+        return reject(reason);
+      }));


### PR DESCRIPTION
This enables other components to do two things:

- When parsing is done, read the parsed contents (used for continously sending pre-flight queries in Neo4j Browser to check for Cypher warnings in the queries)

- Being able to check if we have the latest parsed version when we want to execute the query. If not, we can call `editorSupport.ensureVersion().then()` to wait for it.

Check the included React app for usage and the console for the output.