### PR TITLE
Expose a `parse` function through public interface

### DIFF
--- a/cypher-codemirror/src/codemirror-cypher.js
+++ b/cypher-codemirror/src/codemirror-cypher.js
@@ -19,7 +19,7 @@
  */
 
 import codemirror from 'codemirror';
-import { CypherEditorSupport, TreeUtils } from 'cypher-editor-support/src/index';
+import { CypherEditorSupport, TreeUtils, parse as importedParse } from 'cypher-editor-support/src/index';
 import './codemirror-cypher-mode';
 
 function translatePosition(from, to) {
@@ -113,3 +113,5 @@ export function createCypherEditor(input, settings) {
 
   return { editor, editorSupport };
 }
+
+export const parse = importedParse;

--- a/cypher-codemirror/src/react/CypherCodeMirror.js
+++ b/cypher-codemirror/src/react/CypherCodeMirror.js
@@ -19,7 +19,7 @@
  */
 
 import * as React from 'react';
-import { createCypherEditor } from '../codemirror-cypher';
+import { createCypherEditor, parse } from '../codemirror-cypher';
 
 function triggerAutocompletion(cm, changed) {
   if (changed.text.length !== 1) {
@@ -85,7 +85,7 @@ export default class CypherCodeMirror extends React.Component {
     this.editorSupport.setSchema(this.schema);
   }
   parseContent = () => {
-    const { referencesListener } = this.editorSupport.parse(this.editor.getValue());
+    const { referencesListener } = parse(this.editor.getValue());
     const { queriesAndCommands } = referencesListener;
     console.log('queriesAndCommands: ', queriesAndCommands);
   };

--- a/cypher-codemirror/src/react/CypherCodeMirror.js
+++ b/cypher-codemirror/src/react/CypherCodeMirror.js
@@ -84,7 +84,11 @@ export default class CypherCodeMirror extends React.Component {
     });
     this.editorSupport.setSchema(this.schema);
   }
-
+  parseContent = () => {
+    const { referencesListener } = this.editorSupport.parse(this.editor.getValue());
+    const { queriesAndCommands } = referencesListener;
+    console.log('queriesAndCommands: ', queriesAndCommands);
+  };
   componentWillUpdate(nextProps) {
     if (nextProps.schema) {
       this.schema = nextProps.schema;
@@ -102,6 +106,11 @@ export default class CypherCodeMirror extends React.Component {
     const setInput = (input) => {
       this.input = input;
     };
-    return <div className="Codemirror-Container" ref={setInput} />;
+    return (
+      <div>
+        <button onClick={this.parseContent}>Manually parse content</button>
+        <div className="Codemirror-Container" ref={setInput} />
+      </div>
+    );
   }
 }

--- a/cypher-editor-support/src/CypherEditorSupport.js
+++ b/cypher-editor-support/src/CypherEditorSupport.js
@@ -18,11 +18,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import antlr4 from 'antlr4';
-import { CypherParser } from './_generated/CypherParser';
-import { CypherLexer } from './_generated/CypherLexer';
-import { ErrorListener } from './errors/ErrorListener';
-import { ReferencesListener } from './references/ReferencesListener';
 import { ReferencesProvider } from './references/ReferencesProvider';
 import { CompletionTypeResolver } from './completion/CompletionTypeResolver';
 import { AutoCompletion } from './completion/AutoCompletion';
@@ -31,6 +26,7 @@ import { CypherSyntaxHighlight } from './highlight/CypherSyntaxHighlight';
 import { TreeUtils } from './util/TreeUtils';
 import { PositionConverter } from './util/PositionConverter';
 import { retryOperation } from './util/retryOperation';
+import { parse } from './util/parse';
 
 export class CypherEditorSupport {
   schema = {};
@@ -92,7 +88,7 @@ export class CypherEditorSupport {
     this.positionConverter = new PositionConverter(input);
 
     this.input = input;
-    const { parseTree, referencesListener, errorListener } = this.parse(input);
+    const { parseTree, referencesListener, errorListener } = parse(input);
     this.parseTree = parseTree;
 
     const consoleCommandExists = () => {
@@ -126,23 +122,6 @@ export class CypherEditorSupport {
   setSchema(schema) {
     this.schema = schema;
     this.completion.updateSchema(this.schema);
-  }
-
-  parse(input) {
-    const referencesListener = new ReferencesListener();
-    const errorListener = new ErrorListener();
-    const chars = new antlr4.InputStream(input);
-    const lexer = new CypherLexer(chars);
-    lexer.removeErrorListeners();
-    lexer.addErrorListener(errorListener);
-    const tokens = new antlr4.CommonTokenStream(lexer);
-    const parser = new CypherParser(tokens);
-    parser.buildParseTrees = true;
-    parser.removeErrorListeners();
-    parser.addErrorListener(errorListener);
-    parser.addParseListener(referencesListener);
-    const parseTree = parser.cypher();
-    return { parseTree, referencesListener, errorListener };
   }
 
   getElement(line, column) {

--- a/cypher-editor-support/src/CypherEditorSupport.js
+++ b/cypher-editor-support/src/CypherEditorSupport.js
@@ -91,22 +91,9 @@ export class CypherEditorSupport {
     }
     this.positionConverter = new PositionConverter(input);
 
-    const errorListener = new ErrorListener();
-    const referencesListener = new ReferencesListener();
-
-    const chars = new antlr4.InputStream(input);
-    const lexer = new CypherLexer(chars);
-    lexer.removeErrorListeners();
-    lexer.addErrorListener(errorListener);
-    const tokens = new antlr4.CommonTokenStream(lexer);
-    const parser = new CypherParser(tokens);
-    parser.buildParseTrees = true;
-    parser.removeErrorListeners();
-    parser.addErrorListener(errorListener);
-    parser.addParseListener(referencesListener);
-
     this.input = input;
-    this.parseTree = parser.cypher();
+    const { parseTree, referencesListener, errorListener } = this.parse(input);
+    this.parseTree = parseTree;
 
     const consoleCommandExists = () => {
       const ctx = TreeUtils.findChild(this.parseTree, CypherTypes.CONSOLE_COMMAND_CONTEXT);
@@ -139,6 +126,23 @@ export class CypherEditorSupport {
   setSchema(schema) {
     this.schema = schema;
     this.completion.updateSchema(this.schema);
+  }
+
+  parse(input) {
+    const referencesListener = new ReferencesListener();
+    const errorListener = new ErrorListener();
+    const chars = new antlr4.InputStream(input);
+    const lexer = new CypherLexer(chars);
+    lexer.removeErrorListeners();
+    lexer.addErrorListener(errorListener);
+    const tokens = new antlr4.CommonTokenStream(lexer);
+    const parser = new CypherParser(tokens);
+    parser.buildParseTrees = true;
+    parser.removeErrorListeners();
+    parser.addErrorListener(errorListener);
+    parser.addParseListener(referencesListener);
+    const parseTree = parser.cypher();
+    return { parseTree, referencesListener, errorListener };
   }
 
   getElement(line, column) {

--- a/cypher-editor-support/src/index.js
+++ b/cypher-editor-support/src/index.js
@@ -20,12 +20,8 @@
 
 import { CypherEditorSupport } from './CypherEditorSupport';
 import { TreeUtils } from './util/TreeUtils';
+import { parse } from './util/parse';
 import * as CypherTypes from './lang/CypherTypes';
 import CypherKeywords from './lang/CypherKeywords';
 
-export {
-  CypherEditorSupport,
-  CypherTypes,
-  CypherKeywords,
-  TreeUtils,
-};
+export { CypherEditorSupport, CypherTypes, CypherKeywords, TreeUtils, parse };

--- a/cypher-editor-support/src/util/parse.js
+++ b/cypher-editor-support/src/util/parse.js
@@ -1,0 +1,22 @@
+import antlr4 from 'antlr4';
+import { CypherParser } from '../_generated/CypherParser';
+import { CypherLexer } from '../_generated/CypherLexer';
+import { ErrorListener } from '../errors/ErrorListener';
+import { ReferencesListener } from '../references/ReferencesListener';
+
+export const parse = (input) => {
+  const referencesListener = new ReferencesListener();
+  const errorListener = new ErrorListener();
+  const chars = new antlr4.InputStream(input);
+  const lexer = new CypherLexer(chars);
+  lexer.removeErrorListeners();
+  lexer.addErrorListener(errorListener);
+  const tokens = new antlr4.CommonTokenStream(lexer);
+  const parser = new CypherParser(tokens);
+  parser.buildParseTrees = true;
+  parser.removeErrorListeners();
+  parser.addErrorListener(errorListener);
+  parser.addParseListener(referencesListener);
+  const parseTree = parser.cypher();
+  return { parseTree, referencesListener, errorListener };
+};


### PR DESCRIPTION
Usage:

```js
import { parse } from 'cypher-codemirror'

const myString = 'MATCH (n) RETURN n LIMIT 1; RETURN rand();'
const { referencesListener } = parse(myString);
const { queriesAndCommands } = referencesListener;


queriesAndCommands.forEach(q => console.log(q.getText()))
// MATCH (n) RETURN n LIMIT 1
// RETURN rand()
```