### PR TITLE
Autocompletion: Escape cypher types

### DIFF
--- a/cypher-codemirror/dev/common.js
+++ b/cypher-codemirror/dev/common.js
@@ -81,6 +81,7 @@ export const neo4jSchema = {
     { name: ':queries' },
   ],
   labels: [
+    ':Spacey mc spaceface',
     ':Legislator',
     ':State',
     ':Party',
@@ -95,7 +96,7 @@ export const neo4jSchema = {
     ':ELECTED_TO',
     ':PROPOSED_DURING',
     ':SPONSORED_BY',
-    ':VOTED_ON',
+    ':VOTED ON',
     ':REFERRED_TO',
     ':SERVES_ON',
     ':DEALS_WITH',

--- a/cypher-editor-support/src/completion/AutoCompletion.js
+++ b/cypher-editor-support/src/completion/AutoCompletion.js
@@ -24,6 +24,7 @@ import * as CypherTypes from '../lang/CypherTypes';
 import * as CompletionTypes from './CompletionTypes';
 import CypherKeywords from '../lang/CypherKeywords';
 import { TreeUtils } from '../util/TreeUtils';
+import { ecsapeCypher } from '../util/ecsapeCypher';
 
 export const KEYWORD_ITEMS = CypherKeywords.map(keyword => ({
   type: CompletionTypes.KEYWORD,
@@ -104,28 +105,28 @@ class SchemaBasedCompletion extends AbstractCachingCompletion {
         .map(label => ({
           type: CompletionTypes.LABEL,
           view: label,
-          content: label,
+          content: ecsapeCypher(label),
           postfix: null,
         })),
       [CompletionTypes.RELATIONSHIP_TYPE]: (schema.relationshipTypes || [])
         .map(relType => ({
           type: CompletionTypes.RELATIONSHIP_TYPE,
           view: relType,
-          content: relType,
+          content: ecsapeCypher(relType),
           postfix: null,
         })),
       [CompletionTypes.PROPERTY_KEY]: (schema.propertyKeys || [])
         .map(propKey => ({
           type: CompletionTypes.PROPERTY_KEY,
           view: propKey,
-          content: propKey,
+          content: ecsapeCypher(propKey),
           postfix: null,
         })),
       [CompletionTypes.FUNCTION_NAME]: (schema.functions || [])
         .map(({ name, signature }) => ({
           type: CompletionTypes.FUNCTION_NAME,
           view: name,
-          content: name,
+          content: ecsapeCypher(name),
           postfix: signature,
         })),
       [CompletionTypes.PROCEDURE_NAME]: (schema.procedures || [])

--- a/cypher-editor-support/src/util/ecsapeCypher.js
+++ b/cypher-editor-support/src/util/ecsapeCypher.js
@@ -1,0 +1,10 @@
+export const ecsapeCypher = (str) => {
+  const prefix = str.startsWith(':') ? ':' : '';
+  let content = str;
+  if (prefix.length > 0) {
+    content = str.substring(1);
+  }
+  return /^[A-Za-z][A-Za-z0-9_]*$/.test(content)
+        ? prefix + content
+        : `${prefix}\`${content.replace(/`/g, '``')}\``;
+};

--- a/cypher-editor-support/test/autocompletion/escapeCypher.test.js
+++ b/cypher-editor-support/test/autocompletion/escapeCypher.test.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from 'chai';
+import { ecsapeCypher } from '../../src/util/ecsapeCypher';
+
+describe('Escape Cypher', () => {
+  it('only backticks strings with spaces', () => {
+    expect(ecsapeCypher('nospaces')).to.equal('nospaces');
+    expect(ecsapeCypher('with spaces')).to.equal('`with spaces`');
+  });
+});

--- a/cypher-editor-support/test/autocompletion/relationshipPattern.test.js
+++ b/cypher-editor-support/test/autocompletion/relationshipPattern.test.js
@@ -54,7 +54,7 @@ describe('AutoCompletion - Relationship Pattern', () => {
         to: { line: 1, column: 14 },
         items: [
           { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel1', content: ':rel1', postfix: null },
-          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel2', content: ':rel2', postfix: null },
+          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel 2', content: ':`rel 2`', postfix: null },
         ],
       };
       checkCompletion('MATCH (a)-[a:▼b]-', expected);
@@ -67,7 +67,7 @@ describe('AutoCompletion - Relationship Pattern', () => {
         to: { line: 1, column: 13 },
         items: [
           { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel1', content: ':rel1', postfix: null },
-          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel2', content: ':rel2', postfix: null },
+          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel 2', content: ':`rel 2`', postfix: null },
         ],
       };
       checkCompletion('MATCH (a)-[a▼:]-()', expected);
@@ -95,7 +95,7 @@ describe('AutoCompletion - Relationship Pattern', () => {
         to: { line: 1, column: 13 },
         items: [
           { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel1', content: ':rel1', postfix: null },
-          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel2', content: ':rel2', postfix: null },
+          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel 2', content: ':`rel 2`', postfix: null },
         ],
       };
       checkCompletion('MATCH (a)-[a▼:]-()', expected, true);
@@ -108,7 +108,7 @@ describe('AutoCompletion - Relationship Pattern', () => {
         items: [
           { type: CompletionTypes.VARIABLE, view: 'a', content: 'a', postfix: null },
           { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel1', content: ':rel1', postfix: null },
-          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel2', content: ':rel2', postfix: null },
+          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel 2', content: ':`rel 2`', postfix: null },
         ],
       };
       checkCompletion('MATCH (a)-▼[', expected, true);
@@ -120,7 +120,7 @@ describe('AutoCompletion - Relationship Pattern', () => {
         to: { line: 1, column: 13 },
         items: [
           { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel1', content: ':rel1', postfix: null },
-          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel2', content: ':rel2', postfix: null },
+          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel 2', content: ':`rel 2`', postfix: null },
         ],
       };
       checkCompletion('MATCH (a)-[:r▼', expected, true);
@@ -132,7 +132,7 @@ describe('AutoCompletion - Relationship Pattern', () => {
         to: { line: 1, column: 12 },
         items: [
           { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel1', content: ':rel1', postfix: null },
-          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel2', content: ':rel2', postfix: null },
+          { type: CompletionTypes.RELATIONSHIP_TYPE, view: ':rel 2', content: ':`rel 2`', postfix: null },
         ],
       };
       checkCompletion('MATCH (a)-[:▼ return n;', expected, true);

--- a/cypher-editor-support/test/autocompletion/util.js
+++ b/cypher-editor-support/test/autocompletion/util.js
@@ -24,7 +24,7 @@ import { CompletionTypeResolver } from '../../src/completion/CompletionTypeResol
 
 export const schema = {
   labels: [':y', ':x'],
-  relationshipTypes: [':rel1', ':rel2'],
+  relationshipTypes: [':rel1', ':rel 2'],
   propertyKeys: ['prop1', 'prop2'],
   parameters: ['param1', 'param2'],
   functions: [


### PR DESCRIPTION
Escape cypher types with spaces when using autocomplete.

![backticking](https://user-images.githubusercontent.com/849508/56805171-16118580-6820-11e9-8fa5-6fae9545bbb5.gif)

