### PR TITLE
lodash-bump

### DIFF
--- a/cypher-editor-support/package.json
+++ b/cypher-editor-support/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "cypher"
   ],
-  "version": "1.1.6",
+  "version": "1.1.5",
   "author": "Neo Technology Inc.",
   "license": "GPL-3.0",
   "main": "./dist/cypher-editor-support.js",

--- a/cypher-editor-support/package.json
+++ b/cypher-editor-support/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "cypher"
   ],
-  "version": "1.1.5",
+  "version": "1.1.6",
   "author": "Neo Technology Inc.",
   "license": "GPL-3.0",
   "main": "./dist/cypher-editor-support.js",
@@ -37,7 +37,7 @@
   "dependencies": {
     "antlr4": "4.7.0",
     "fuzzaldrin": "2.1.0",
-    "lodash": "4.17.4"
+    "lodash": "4.17.15"
   },
   "devDependencies": {
     "babel-core": "6.25.0",

--- a/cypher-editor-support/yarn.lock
+++ b/cypher-editor-support/yarn.lock
@@ -2156,7 +2156,12 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
This needs to be merged before #27
- Bump lodash in order to remove the following vulnerabilities on Browser:

<img width="575" alt="Screenshot 2019-12-17 at 16 28 46" src="https://user-images.githubusercontent.com/14161129/71014733-517ffd80-20ea-11ea-8014-5847f3f50418.png">