### PR TITLE
version bump of cypher-editor-support

### DIFF
--- a/cypher-codemirror/package.json
+++ b/cypher-codemirror/package.json
@@ -5,7 +5,7 @@
     "cypher",
     "codemirror"
   ],
-  "version": "1.1.5",
+  "version": "1.1.6",
   "author": "Neo Technology Inc.",
   "license": "GPL-3.0",
   "main": "./dist/cypher-codemirror.js",
@@ -46,7 +46,7 @@
     "node": ">=8.2.0"
   },
   "dependencies": {
-    "cypher-editor-support": "1.1.5"
+    "cypher-editor-support": "1.1.6"
   },
   "peerDependencies": {
     "codemirror": "^5.25.0",


### PR DESCRIPTION
- Bump cypher-editor-support version in order to get bumped lodash version. This needs to be merged after #26 