### PR TITLE
Fix types resolution

### DIFF
--- a/.changeset/mighty-chairs-buy.md
+++ b/.changeset/mighty-chairs-buy.md
@@ -1,0 +1,5 @@
+---
+"@neo4j-cypher/editor-support": patch
+---
+
+Update `exports` field to fix issue with TypeScript `Bundler` module resolution mode

--- a/packages/editor-support/package.json
+++ b/packages/editor-support/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": {
       "import": "./es/editor-support.js",
-      "require": "./lib/editor-support.js"
+      "require": "./lib/editor-support.js",
+      "types": "./src/editor-support.d.ts"
     },
     "./src/editor-support.d.ts": {
       "import": "./src/editor-support.d.ts"


### PR DESCRIPTION
This PR fixes the issue occurring when TypeScript module resolution mode is set to `Bundler` mode. Using module in this mode yields following error:

```
error TS7016: Could not find a declaration file for module '@neo4j-cypher/editor-support'. '<redacted>/node_modules/.pnpm/@neo4j-cypher+editor-support@1.0.1/node_modules/@neo4j-cypher/editor-support/es/editor-support.js' implicitly has an 'any' type.
  There are types at '<redacted>/node_modules/@neo4j-cypher/editor-support/src/editor-support.d.ts', but this result could not be resolved when respecting package.json "exports". The '@neo4j-cypher/editor-support' library may need to update its package.json or typings.
```

Adding `types` entry to `exports` field resolves this issue as per local testing with patched `package.json`.

Generated changeset will result in patch as there are no code changes, just the update to the package metadata.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests locally to make sure they pass before opening the PR.

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `npx changeset` and following the instructions. Consult the maintainers if you're unsure what type of version bump the PR should generate.
